### PR TITLE
replace disallowed delete

### DIFF
--- a/index.js
+++ b/index.js
@@ -62,7 +62,7 @@ module.exports.decode = function(string) {
 	while (char_nbr < string_len) {
 		var idx = string.charCodeAt(char_nbr++) - 32;
 		if ((idx < 0) || (idx >= decoder.length)) {
-			delete dest;
+			dest = undefined;
 			return;
 		}
 		value = (value * 85) + decoder[idx];


### PR DESCRIPTION
While passing a package that depends on z85 through babel It threw an error regarding the illegitimate use of ```delete``` (due to 'use strict'). This commit fixes the issue.